### PR TITLE
Fix SIM card dump argument

### DIFF
--- a/source/simfrom.sh
+++ b/source/simfrom.sh
@@ -16,4 +16,4 @@ fi
 echo "Installing required libs..."
 sudo pip3 install paramiko
 echo "Launching shell"
-python3 ./source/scripts/sim.py restore
+python3 ./source/scripts/sim.py dump


### PR DESCRIPTION
## Summary
- fix `simfrom.sh` to use `dump` mode when calling `sim.py`

## Testing
- `bash -n source/simfrom.sh`

------
https://chatgpt.com/codex/tasks/task_e_684f9d88f1248320ba1785d4237a49f1