### PR TITLE
Fix typo in iCloud removal option

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -71,7 +71,7 @@ echo "Features: Bypass Activation lock, Remove old icloud account, root shell to
 echo "Select one option using up/down keys and enter to confirm:"
 echo
 chmod +x ./source/exe/jk
-options=( "Icloud bypass IOS 12.3-13.2.3! NO SIM CARD (AUTOMATIC ONE)" "newPHP ICLOUD BYPASS WITH SIM  " "Removes old icloud account conected to the device  (JAILBREAK REQUIRED)" "Jailbreak the device" "Exit")
+options=( "Icloud bypass IOS 12.3-13.2.3! NO SIM CARD (AUTOMATIC ONE)" "newPHP ICLOUD BYPASS WITH SIM  " "Removes old icloud account connected to the device  (JAILBREAK REQUIRED)" "Jailbreak the device" "Exit")
 
 select_option "${options[@]}"
 choice=$?


### PR DESCRIPTION
### Motivation
- Correct a spelling mistake in the interactive menu to improve clarity and user experience.

### Description
- In `start.sh` updated the `options` array entry from `"Removes old icloud account conected to the device  (JAILBREAK REQUIRED)"` to `"Removes old icloud account connected to the device  (JAILBREAK REQUIRED)"`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967c175b0b08320b98fe035a90f5299)